### PR TITLE
Fix filenames

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - name: "Get version"
         run: |
-          if [[ $GITHUB_REF =~ ^refs/tag/ ]]
-          then version="${GITHUB_REF#refs/tag/}"
+          if [[ $GITHUB_REF =~ ^refs/tags/ ]]
+          then version="${GITHUB_REF#refs/tags/}"
           else version=master
           fi
           echo "version=$version" > "$GITHUB_OUTPUT"
@@ -54,8 +54,8 @@ jobs:
     steps:
       - name: "Get version"
         run: |
-          if [[ $GITHUB_REF =~ ^refs/tag/ ]]
-          then version="${GITHUB_REF#refs/tag/}"
+          if [[ $GITHUB_REF =~ ^refs/tags/ ]]
+          then version="${GITHUB_REF#refs/tags/}"
           else version=master
           fi
           echo "version=$version" > "$GITHUB_OUTPUT"
@@ -86,8 +86,8 @@ jobs:
       - name: "Get version"
         shell: bash
         run: |
-          if [[ $GITHUB_REF =~ ^refs/tag/ ]]
-          then version="${GITHUB_REF#refs/tag/}"
+          if [[ $GITHUB_REF =~ ^refs/tags/ ]]
+          then version="${GITHUB_REF#refs/tags/}"
           else version=master
           fi
           echo "version=$version" > "$GITHUB_OUTPUT"


### PR DESCRIPTION
The filenames are expected as libcurl-linux-8.4.0-1-Debug.tar.gz not as libcurl-linux-master-Debug.tar.gz.
This PR will fix that.
Please release 8.4.0-2 after this PR is merged.